### PR TITLE
Update littler

### DIFF
--- a/README
+++ b/README
@@ -1,15 +1,19 @@
-Last updated 14 October 2013
+Last updated 05 March 2020
 ds351.0 (NCEP ADP Global Upper Air Observation Subsets, daily Apr1998-continuing)
 
 Description and instructions to use the included extraction program:
 =================================================================================
 
 These individual programs can be used to extract general 
-atmospheric variables from adp BUFR files into simple text 
+atmospheric variables from NCEP ADP BUFR files into simple text 
 files.  
 
 To compile the BUFR libraries and extraction code, go to the 
 install directory. Execute the install.sh script to complete the compilations.
+The most recent version of BUFRLIB is required to compile this code; software
+download and installation instructions are provided at:
+
+https://www.emc.ncep.noaa.gov/index.php?branch=BUFRLIB
 
 The executables will be placed in the exe directory.  Execute
 the desired executable and enter the BUFR input file name to extract
@@ -20,7 +24,7 @@ exe/bufr_upa2ob.x:        used to convert gdas.adpupa.tHHz.YYYYMMHH.bufr files t
 exe/bufr_craft2ob.x:      used to convert gdas.aircft.tHHz.YYYYMMHH.bufr files to obs format.
 exe/bufr_aircar2ob.x:     used to convert gdas.aircar.tHHz.YYYYMMHH.bufr files to obs format.
 exe/bufr_sat2ob.x:        used to convert gdas.satwnd.tHHz.YYYYMMHH.bufr files to obs format.
-exe/runob2lit_imd_obs.x:  used to convert/combine obs format files into one littlr format file.
+exe/runob2lit_imd_obs.x:  used to convert/combine obs format files into one little_r format file.
 exe/files.txt  edit to include desired obs files to be input into the runob2lit_imd_obs.x program.
                example files are currently listed in the files.txt file. 
 
@@ -33,8 +37,8 @@ References:
 
 A guide to the BUFR libraries can be found at:
 
-http://www.nco.ncep.noaa.gov/dmqab/decoders/BUFRLIB/toc/
+https://www.emc.ncep.noaa.gov/index.php?branch=BUFRLIB
 
 Definitions for BUFR MNEMONIC headers can be found in the doc directory 
 and at: 
-http://www.emc.ncep.noaa.gov/mmb/data_processing/bufrtab_tableb.htm 		
+https://www.emc.ncep.noaa.gov/BUFRLIB/tables/bufrtab_tableb.html 		

--- a/src/bufr_aircar2ob.f
+++ b/src/bufr_aircar2ob.f
@@ -1,262 +1,215 @@
-        PARAMETER       ( MXMN = 8 )
-        PARAMETER       ( MXLV = 86 )
-        PARAMETER       ( NVAR = 17 )
-        PARAMETER       ( NSTR = 4 )
+      PARAMETER ( MXMN = 8 )
+      PARAMETER ( MXLV = 86 )
+      PARAMETER ( NVAR = 17 )
+      PARAMETER ( NSTR = 4 )
 
-        COMMON /BITBUF/ MAXBYT,IBIT,IBAY(5000),MBYT(32),MBAY(5000,32)
+      REAL*8 r8arr(MXMN, MXLV),  r8arr2(MXMN, MXLV),
+     +       r8arr3(MXMN, MXLV), r8arr4(MXMN, MXLV) 
 
-        REAL*8          r8arr ( MXMN, MXLV ), r8arr2(MXMN, MXLV ),
-     +                  r8arr3 ( MXMN, MXLV ), r8arr4(MXMN, MXLV ) 
-
-        PARAMETER       ( MXBF = 16000 )
-        PARAMETER       (iu=9,iou=10,nz=9999999)
+      PARAMETER (iu=9,iou=10)
  
-        dimension pr(nz),tt(nz),td(nz)         
+      real pr,tt,td         
+      integer xht, nlev, iargc, n, minu, k
+      real xpr,xu,xv
+      real temp,v,zx,d
+      real lat, lon
+      real xt,xtd
+      character*20 fin,fout
+      character*10 date_tag,date
+      character*6 dname
+      character argv*300,minute*2,M11*2,mins*2
+      character*12 ilev,xy,xm,xd,xh,xmin,M5,M6,M7,M8
+      character*12 M10,M1,M2,min,M3,M4,xn1,xn2,xn3,xn4,M9
+      real wlon,elon,slat,nlat
 
-        integer  xht,nlev,iargc, n,minu,k
-        real  xpr,xu,xv
-        real  temp,v(nz),zx(nz),d(nz)
-        real  lat(nz), lon(nz)
-        real xt,xtd
-        character*20 fin,fout
-        character*10  date_tag,date(nz)
-        character*6 dname
-        character   argv*300,minute*2,M11*2,mins(nz)*2
-        character*12 ilev,xy,xm,xd,xh,xmin,M5,M6,M7,M8
-        character*12 M10,M1,M2,min,M3,M4,xn1,xn2,xn3,xn4,M9
-        real wlon,elon,slat,nlat
+      CHARACTER csubset*8, inf*200, outstg*200
+      INTEGER y, z, i, idate, iflag
 
-        CHARACTER       cbfmsg*(MXBF),
-     +                  csubset*8, inf*200, outstg*200
+      CHARACTER*80 ostr(NSTR)
 
-        CHARACTER*80   ostr(NSTR)
-
-        INTEGER         ibfmsg ( MXBF / 4 ), ln, code,y,z,i,idate
-
-        LOGICAL         msgok
-
-        EQUIVALENCE     ( cbfmsg (1:4), ibfmsg (1) )
-
-        ostr(1)='ACID ACRN ARST'
-        ostr(2)='YEAR MNTH DAYS HOUR MINU'
-        ostr(3)='CLAT CLON PRLC IALT'
-        ostr(4)='MIXR REHU TMDB WDIR WSPD'
+      ostr(1)='ACID ACRN ARST'
+      ostr(2)='YEAR MNTH DAYS HOUR MINU'
+      ostr(3)='CLAT CLON PRLC IALT'
+      ostr(4)='MIXR REHU TMDB WDIR WSPD'
 
 C*-----------------------------------------------------------------------
 c*    Read the command-line arguments
 c*      
-        n = iargc()
-        IF (n .GE. 2) THEN
-          call getarg( 1, argv )
-          inf=argv
-          call getarg(2,argv)
-          date_tag=argv
-          IF (n .eq. 6) THEN  ! User-specified lat/lon boundaries
-            call getarg(3,argv)
-            read(argv,*) wlon
-            call getarg(4,argv)
-            read(argv,*) elon
-            call getarg(5,argv)
-            read(argv,*) slat
-            call getarg(6,argv)
-            read(argv,*) nlat
-            write(*,*) 'Lon/lat boundaries: ',wlon,elon,slat,nlat
-          ELSE  ! Default lon/lat boundaries
-            slat = -90.
-            nlat = 90.
-            wlon = -180.
-            elon = 180.
-          END IF
-        ELSE
-          write(*,*) 'Usage: bufr_aircar2ob.x gdas.adpsfc.t<HH>z.
-     +<YYYYMMDD>.bufr.be <YYYYMMDDHH> west_lon east_lon 
-     +south_lat north_lat'
-          STOP
-        END IF
-
-!************************************
-        !processing start from below
-
-C*-----------------------------------------------------------------------
-
-C*      Open the BUFR messages file.
-
+      n = iargc()
+      IF (n .GE. 2) THEN
         call getarg( 1, argv )
         inf=argv
         call getarg(2,argv)
         date_tag=argv
+        IF (n .eq. 6) THEN  ! User-specified lat/lon boundaries
+          call getarg(3,argv)
+          read(argv,*) wlon
+          call getarg(4,argv)
+          read(argv,*) elon
+          call getarg(5,argv)
+          read(argv,*) slat
+          call getarg(6,argv)
+          read(argv,*) nlat
+          write(*,*) 'Lon/lat boundaries: ',wlon,elon,slat,nlat
+        ELSE  ! Default lon/lat boundaries
+          slat = -90.
+          nlat = 90.
+          wlon = -180.
+          elon = 180.
+        END IF
+      ELSE
+        write(*,*) 'Usage: bufr_aircar2ob.x gdas.adpsfc.t<HH>z.
+     +<YYYYMMDD>.bufr.be <YYYYMMDDHH> west_lon east_lon 
+     +south_lat north_lat'
+        STOP
+      END IF
 
-c*        write(*,*) 'enter input BUFR file?'
-c*        read(*,'(a)') inf 
-c*        write(*,*) 'Date_tag (YYYYMMDDHH) : '
-c*        read(*,fmt='(a10)') date_tag
+C*-----------------------------------------------------------------------
+C*    Open the BUFR messages file.
+      OPEN(UNIT=11, FILE=inf, form='unformatted')
 
-        dname=' AIREP'
-        fout= "Airca"//date_tag//'.obs'
-     
-        OPEN  ( UNIT = 11, FILE =inf,form='unformatted' )
-        open(iou,file=fout,status='unknown',form='formatted')
- 
-        iflag = 0
-      nlev = 1
-        dumm=99999.9
+      call getarg( 1, argv )
+      inf=argv
+      call getarg(2,argv)
+      date_tag=argv
 
-        isurf = 0
-        ibogus = 0
-        ter = dumm
-        dslp= dumm
-        do k=1,nz
-         date(k)='MMMMMMMMMM'
-         mins(k)='MM'
-          pr(k)=dumm
-          zx(k)=dumm
-          tt(k)=dumm
-          td(k)=dumm
-          d(k)=dumm
-          v(k)=dumm
-        enddo
-!********************************************
+      dname=' AIREP'
+      fout= "Airca"//date_tag//'.obs'
 
-C*      Open the BUFR tables file.
+c     Open output file
+      open(iou, file=fout, status='unknown', form='formatted')
+      write(iou,fmt='(a10)') date_tag
 
-C*        OPEN  ( UNIT = 12, FILE = 'bufrtab.example' )
+      iflag=0 
+      nlev=1
+      dumm=99999.9
 
-C*      Open output file
+      isurf=0
+      ibogus=0
+      ter=dumm
+      dslp=dumm
+      date='MMMMMMMMMM'
+      mins='MM'
+      pr=dumm
+      zx=dumm
+      tt=dumm
+      td=dumm
+      d=dumm
+      v=dumm
 
-
-
+C*-----------------------------------------------------------------------
 C*      Associate the tables file with the messages file, and identify
 C*      the latter to the BUFRLIB software.
 
-        CALL OPENBF  ( 11, 'IN', 11 )
+      CALL OPENBF(11, 'IN', 11)
 
 C*      Specify that we would like IDATE values returned using 10 digits
 C*      (i.e. YYYYMMDDHH ).
 
-        CALL DATELEN  ( 10 )
-     
+      CALL DATELEN(10)
 
-        DO WHILE  ( .true. )
+C*-----------------------------------------------------------------------
+      DO WHILE ( .true. )
 
-C*          Read the next BUFR message.
+C*      Read the next BUFR message.
 
-           call readns(11,csubset,idate,ierr)
-C*           code = IUPBS1(MBAY,33) 
-C*            write(*,*)' idate: ',idate,'  ',csubset,' ',code
-c            write(*,*)' idate: ',idate,'  ',csubset
-            IF  ( ierr .eq.  -1 )  THEN
-                write(*,*) '....all records read.'
-                CALL CLOSBF  ( 11 )
-                Goto 1000  
-            END IF
+        call readns(11,csubset,idate,ierr)
+c        write(*,*)' idate: ',idate,'  ',csubset
+        IF (ierr .eq.  -1) THEN
+          write(*,*) '....all records read.'
+          CALL CLOSBF  ( 11 )
+          GOTO 2000  
+        END IF
 
-            msgok = .true.
+C*      At this point, we have a data subset within the
+C*      internal arrays of BUFRLIB, and we can now begin
+C*      reading actual data values:
 
+        CALL UFBINT(11, r8arr,  MXMN, MXLV, nlv, ostr(1))
+        CALL UFBINT(11, r8arr2, MXMN, MXLV, nlv, ostr(2))
+        CALL UFBINT(11, r8arr3, MXMN, MXLV, nlv, ostr(3))
+        CALL UFBINT(11, r8arr4, MXMN, MXLV, nlv, ostr(4))
 
-            DO WHILE  ( msgok )
+        minu=int(r8arr2(5,1))
+        write (unit=minute, FMT='(I2)') minu
 
+        DO k=1,2
+           IF ( minute (k:k) .eq. ' ') THEN
+             minute (k:k) = '0'
+           ENDIF
+        ENDDO 
 
-C*            At this point, we have a data subset within the
-C*            internal arrays of BUFRLIB, and we can now begin
-C*            reading actual data values:
+        DO z = 1, nlv
+          WRITE (UNIT=outstg, FMT='(I10,1x,A8,2(1X,A8),
+     +           1X,A4,1X,F6.1,4(1X,F4.1),1X,F6.1,1x,F5.1,
+     +           2(1X,F8.1),2(1X,F4.1),3(1X,F5.1))') 
+     +           idate,csubset,
+     +           (r8arr(i,z), i=1,3),(r8arr2(i,z), i=1,5),
+     +           (r8arr3(i,z), i=1,4),(r8arr4(i,z), i=1,5)
+          DO y = 1,200
+            IF ( outstg (y:y) .eq. '*') THEN
+              outstg (y:y) = 'm'
+            ENDIF
+          ENDDO
 
+          read(outstg,21) M10,xn1,xn2,xn3,xn4,xy,xm,xd,
+     &                    xh,xmin,M1,M2,M3,M4,M5,M6,M7,M8,M9
+          read(minute,22) M11
 
-              CALL UFBINT  ( 11, r8arr, MXMN, MXLV, nlv, ostr(1))
-              CALL UFBINT  ( 11, r8arr2, MXMN, MXLV, nlv, ostr(2))
-              CALL UFBINT  ( 11, r8arr3, MXMN, MXLV, nlv, ostr(3))
-              CALL UFBINT  ( 11, r8arr4, MXMN, MXLV, nlv, ostr(4))
-            minu=int(r8arr2(5,1))
-            write (unit=minute, FMT='(I2)') minu
-            DO k=1,2
-               IF ( minute (k:k) .eq. ' ') THEN
-                 minute (k:k) = '0'
-               ENDIF
-            ENDDO 
-            DO z = 1, nlv
-              WRITE (UNIT=outstg, FMT='(I10,1x,A8,2(1X,A8),
-     +          1X,A4,1X,F6.1, 
-     +          4(1X,F4.1),1X,F6.1,1x,F5.1,2(1X,F8.1),2(1X,F4.1),
-     +          3(1X,F5.1))') idate,csubset,
-     +          (r8arr(i,z), i = 1,3),(r8arr2(i,z), i = 1,5),
-     +          (r8arr3(i,z), i = 1,4),(r8arr4(i,z), i = 1,5)
-              DO y = 1,200
-               IF ( outstg (y:y) .eq. '*') THEN
-                 outstg (y:y) = 'm'
-               ENDIF
-              ENDDO
-              read(outstg,21)M10,xn1,xn2,xn3,xn4,xy,xm,xd,
-     &        xh,xmin,M1,M2,M3,M4,M5,M6,M7,M8,M9
-              read(minute,22) M11
-21            format(A10,1X,3(A8,1X),A4,1X,A6,
-     &         4(1X,A4),1X,A6,1X,A5,
-     &         2(1X,A8),2(1X,A4),2(1X,A5),1X,A5)
-22            format(A2)
-!              write(*,*)M10,M1,M2,M3,M4,M5,M6,M7,M8,M9
-! *****************************************************
-               !preparing variable for out put
-               iflag =iflag+1
-               j=iflag
+21        format(A10,1X,3(A8,1X),A4,1X,A6,4(1X,A4),1X,A6,1X,A5,
+     &           2(1X,A8),2(1X,A4),2(1X,A5),1X,A5)
+22        format(A2)
 
-               CALL READMval(M1,lat(j))
-               CALL READMval(M2,lon(j))
-               CALL READMval(M3,pr(j))
-               CALL READMval(M7,tt(j))
-               CALL READMval(M8,d(j))
-               CALL READMval(M9,v(j))
+C*-----------------------------------------------------------------------
+c         Prepare output
+
+          CALL READMval(M1,lat)
+          CALL READMval(M2,lon)
+          CALL READMval(M3,pr)
+          CALL READMval(M7,tt)
+          CALL READMval(M8,d)
+          CALL READMval(M9,v)
                
-!               write(*,*)'PR',pr(j)
-               if(pr(j) .ne. 0 .and. pr(j) .ne. 99999.9 ) then
-                  pr(j)= pr(j)/100
-               end if
-!               write(*,*)'PRM',pr(j)
-               date(j)=M10
-               mins(j)=M11 
-!               write(*,*)iflag
-            ENDDO
+          if(pr.ne.0 .and. pr.ne.99999.9) then
+            pr=pr/100
+          end if
 
-            
-            
+          date=M10
+          mins=M11
+          
+c         Write output 
+          if (iflag.eq.0) then
+            write(iou,fmt='(a10)') date_tag
+            iflag=1
+          endif
+          if(slat<=lat .and. nlat>=lat .and.
+     &       wlon<=lon .and. elon>=lon) then
+            write(iou,111) isurf,dname,dname,date,mins,
+     &                     lat,lon,ter,dslp,nlev,ibogus
+            write(iou,112) pr,zx,tt,td,d,v
+          endif
 
-              CALL READSB  ( 11, ierrsb )
+111       format(i1,2(1x,a6),1x,a10,a2,4(f7.1,1x),i3,1x,i1)
+112       format(6(f7.1,1x))
+          
+        ENDDO
+      END DO
 
-              IF  ( ierrsb .ne. 0 )  THEN
+C*-----------------------------------------------------------------------
 
-                  msgok = .false.
-
-              ELSE
-              END IF
-
-            END DO
-
-        END DO
-
-1000   if (iflag .ne. 0) then
-
-          write(iou,fmt='(a10)') date_tag
-       do k = 1,iflag
-        if(slat <= lat(k) .and. nlat >= lat(k) .and.
-     &   wlon <= lon(k) .and. elon >= lon(k)) then
-         write(iou,111)isurf,dname,dname,date(k),mins(k),
-     &     lat(k),lon(k),ter,dslp,nlev,ibogus
-         write(iou,112)pr(k),zx(k),tt(k),td(k),d(k),v(k)
-        endif
-       enddo
-111    format(i1,2(1x,a6),1x,a10,a2,4(f7.1,1x),i3,1x,i1)
-112    format(6(f7.1,1x))
-
-       endif
-        write(*,*)'nlev ', nlev
 2000  stop 99999
 
       END
       
+C*-----------------------------------------------------------------------
       SUBROUTINE READMval(M1,fl)
-           character*8 M1
-           dumm=99999.9
-           if(M1(1:1) ==  'm') then
-               fl = dumm
-           else
-               read(M1,*)fl
-           endif
-       RETURN
-         END
+      character*8 M1
+      dumm=99999.9
+      if(M1(1:1) ==  'm') then
+        fl = dumm
+      else
+        read(M1,*)fl
+      endif
+      
+      RETURN
+      END

--- a/src/bufr_craft2ob.f
+++ b/src/bufr_craft2ob.f
@@ -1,264 +1,214 @@
-        PARAMETER       ( MXMN = 8 )
-        PARAMETER       ( MXLV = 86 )
-        PARAMETER       ( NVAR = 20 )
-        PARAMETER       ( NSTR = 6 )
+      PARAMETER ( MXMN = 8 )
+      PARAMETER ( MXLV = 86 )
+      PARAMETER ( NVAR = 20 )
+      PARAMETER ( NSTR = 6 )
 
-        COMMON /BITBUF/ MAXBYT,IBIT,IBAY(5000),MBYT(32),MBAY(5000,32)
+      REAL*8 r8arr(MXMN, MXLV),  r8arr2(MXMN, MXLV),
+     +       r8arr3(MXMN, MXLV), r8arr4(MXMN, MXLV),
+     +       r8arr5(MXMN, MXLV), r8arr6(MXMN, MXLV) 
 
-        REAL*8          r8arr ( MXMN, MXLV ), r8arr2(MXMN, MXLV ),
-     +                  r8arr3 ( MXMN, MXLV ), r8arr4(MXMN, MXLV ),
-     +                  r8arr5 (MXMN, MXLV), r8arr6(MXMN, MXLV) 
+      parameter(iu=9,iou=10)
 
-        PARAMETER       ( MXBF = 16000 )
+      real pr,tt,td,zx1,zx2
+      integer xht,nlev,iargc,n,minu,k
+      real xpr,xu,xv
+      real temp,v,zx,d
+      real lat, lon
+      real xt,xtd
+      character*30 fin,fout
+      character*10 date_tag, date
+      character*6 dname
+      character argv*300,minute*2,M11*2,mins*2
+      character*12 ilev,xy,xm,xd,xh,xmin,M5,M6,M7,M8
+      character*12 M10,M1,M2,min,M3,M4,xn1,xn2,xn3,xn4,M9
+      real wlon,elon,slat,nlat
 
-        parameter(iu=9,iou=10,nz=9999999)
+      CHARACTER csubset*8, inf*200, outstg*200
+      INTEGER y, z, i, idate, iflag
 
-        dimension pr(nz),tt(nz),td(nz),zx1(nz),zx2(nz)
+      CHARACTER*80   ostr(NSTR)
 
-        integer  xht,nlev,iargc,n,minu,k
-        real  xpr,xu,xv
-        real  temp,v(nz),zx(nz),d(nz)
-        real  lat(nz), lon(nz)
-        real xt,xtd
-        character*30 fin,fout
-        character*10  date_tag,date(nz)
-        character*6 dname
-        character   argv*300,minute*2,M11*2,mins(nz)*2
-        character*12 ilev,xy,xm,xd,xh,xmin,M5,M6,M7,M8
-        character*12 M10,M1,M2,min,M3,M4,xn1,xn2,xn3,xn4,M9
-        real wlon,elon,slat,nlat
-
-        CHARACTER       cbfmsg*(MXBF),
-     +                  csubset*8, inf*200, outstg*200
-
-        CHARACTER*80   ostr(NSTR)
-
-        INTEGER         ibfmsg ( MXBF / 4 ), ln, code,y,z,i,idate
-
-        LOGICAL         msgok
-
-        EQUIVALENCE     ( cbfmsg (1:4), ibfmsg (1) )
-
-        ostr(1)='RPID YEAR MNTH DAYS'
-        ostr(2)='HOUR MINU CLAT CLON FLVL PSAL'
-        ostr(3)='CLATH CLONH HMSL'
-        ostr(4)='TMDB WDIR WSPD'
-        ostr(5)='DGOT HBOT HTOP'
-        ostr(6)='HOCB HOCT'
+      ostr(1)='RPID YEAR MNTH DAYS'
+      ostr(2)='HOUR MINU CLAT CLON FLVL PSAL'
+      ostr(3)='CLATH CLONH HMSL'
+      ostr(4)='TMDB WDIR WSPD'
+      ostr(5)='DGOT HBOT HTOP'
+      ostr(6)='HOCB HOCT'
 
 C*-----------------------------------------------------------------------
 c*    Read the command-line arguments
 c*      
-        n = iargc()
-        IF (n .GE. 2) THEN
-          call getarg( 1, argv )
-          inf=argv
-          call getarg(2,argv)
-          date_tag=argv
-          IF (n .eq. 6) THEN  ! User-specified lat/lon boundaries
-            call getarg(3,argv)
-            read(argv,*) wlon
-            call getarg(4,argv)
-            read(argv,*) elon
-            call getarg(5,argv)
-            read(argv,*) slat
-            call getarg(6,argv)
-            read(argv,*) nlat
-            write(*,*) 'Lon/lat boundaries: ',wlon,elon,slat,nlat
-          ELSE  ! Default lon/lat boundaries
-            slat = -90.
-            nlat = 90.
-            wlon = -180.
-            elon = 180.
-          END IF
-        ELSE
-          write(*,*) 'Usage: bufr_aircar2ob.x gdas.adpsfc.t<HH>z.
+      n = iargc()
+      IF (n .GE. 2) THEN
+        call getarg( 1, argv )
+        inf=argv
+        call getarg(2,argv)
+        date_tag=argv
+        IF (n .eq. 6) THEN  ! User-specified lat/lon boundaries
+          call getarg(3,argv)
+          read(argv,*) wlon
+          call getarg(4,argv)
+          read(argv,*) elon
+          call getarg(5,argv)
+          read(argv,*) slat
+          call getarg(6,argv)
+          read(argv,*) nlat
+          write(*,*) 'Lon/lat boundaries: ',wlon,elon,slat,nlat
+        ELSE  ! Default lon/lat boundaries
+          slat = -90.
+          nlat = 90.
+          wlon = -180.
+          elon = 180.
+        END IF
+      ELSE
+        write(*,*) 'Usage: bufr_aircar2ob.x gdas.adpsfc.t<HH>z.
      +<YYYYMMDD>.bufr.be <YYYYMMDDHH> west_lon east_lon 
      +south_lat north_lat'
-          STOP
-        END IF
+        STOP
+      END IF
 
 C*-----------------------------------------------------------------------
+C*    Open the BUFR messages file.
+      OPEN(UNIT=11, FILE=inf, form='unformatted')
 
-C*      Open the BUFR messages file.
+      dname=' AIREP'
+      fout= "Aircraft"//date_tag//'.obs'
 
-c*        write(*,*) 'enter input BUFR file?'
-c*        read(*,'(a)') inf 
-        OPEN  ( UNIT = 11, FILE =inf,form='unformatted' )
+c     Open output file
+      open(iou, file=fout, status='unknown', form='formatted')
 
-c*        write(*,*) 'Date_tag (YYYYMMDDHH) : '
-c*        read(*,fmt='(a10)') date_tag
+      iflag=0
+      nlev=1
+      dumm=99999.9
 
-       !please change here
+      isurf=0
+      ibogus=0
+      ter=dumm
+      dslp=dumm
+      date='MMMMMMMMMM'
+      mins='MM'
+      pr=dumm
+      zx=dumm
+      tt=dumm
+      td=dumm
+      d=dumm
+      v=dumm
 
-        dname=' AIREP'
-        fout= "Aircraft"//date_tag//'.obs'
-
-        open(iou,file=fout,status='unknown',form='formatted')
-
-        iflag = 0
-        nlev = 1
-        dumm=99999.9
-
-        isurf = 0
-        ibogus = 0
-        ter = dumm
-        dslp= dumm
-        do k=1,nz
-         date(k)='MMMMMMMMMM'
-         mins(k)='MM'
-          pr(k)=dumm
-          zx(k)=dumm
-          tt(k)=dumm
-          td(k)=dumm
-          d(k)=dumm
-          v(k)=dumm
-        enddo
-
-C*      Open the BUFR tables file.
-
-C*        OPEN  ( UNIT = 12, FILE = 'bufrtab.example' )
-
-
+C*-----------------------------------------------------------------------
 C*      Associate the tables file with the messages file, and identify
 C*      the latter to the BUFRLIB software.
 
-        CALL OPENBF  ( 11, 'IN', 11 )
+      CALL OPENBF(11, 'IN', 11)
 
 C*      Specify that we would like IDATE values returned using 10 digits
 C*      (i.e. YYYYMMDDHH ).
 
-        CALL DATELEN  ( 10 )
+      CALL DATELEN(10)
      
-        ln=0 
+C*-----------------------------------------------------------------------
+      DO WHILE ( .true. )
 
-        DO WHILE  ( .true. )
+C*      Read the next BUFR message.
 
-C*          Read the next BUFR message.
-
-           call readns(11,csubset,idate,ierr)
-C*           code = IUPBS1(MBAY,33) 
-C*            write(*,*)' idate: ',idate,'  ',csubset,' ',code
+        CALL READNS(11, csubset, idate, ierr)
 c            write(*,*)' idate: ',idate,'  ',csubset
-            IF  ( ierr .eq.  -1 )  THEN
-                write(*,*) '....all records read, Exit'
-                CALL CLOSBF  ( 11 )
-                goto 1000 
-            END IF
+        IF (ierr .eq.  -1) THEN
+          WRITE(*,*) '[bufr_craft2ob]....all records read, Exit'
+          CALL CLOSBF(11)
+          GOTO 1000 
+        END IF
 
-            msgok = .true.
+C*      At this point, we have a data subset within the
+C*      internal arrays of BUFRLIB, and we can now begin
+C*      reading actual data values:
 
+        CALL UFBINT(11, r8arr,  MXMN, MXLV, nlv, ostr(1))
+        CALL UFBINT(11, r8arr2, MXMN, MXLV, nlv, ostr(2))
+        CALL UFBINT(11, r8arr3, MXMN, MXLV, nlv, ostr(3))
+        CALL UFBINT(11, r8arr4, MXMN, MXLV, nlv1, ostr(4))
+        CALL UFBINT(11, r8arr5, MXMN, MXLV, nlv, ostr(5))
+        CALL UFBINT(11, r8arr6, MXMN, MXLV, nlv, ostr(6))
 
-            DO WHILE  ( msgok )
+        minu=int(r8arr2(2,1))
+        write (unit=minute, FMT='(I2)') minu
 
+        DO k=1,2
+          IF (minute (k:k) .eq. ' ') THEN
+            minute (k:k) = '0'
+          ENDIF
+        ENDDO
 
-C*            At this point, we have a data subset within the
-C*            internal arrays of BUFRLIB, and we can now begin
-C*            reading actual data values:
+        DO z = 1,nlv1
+          WRITE (UNIT=outstg, FMT='(I10,1x,A8,1X,A6,
+     +           1X,F6.1,4(1X,F4.1), 
+     +           2(1X,F6.1),2(1X,F7.1),2(1X,F6.1),1X,F7.1,
+     +           2(1X,F5.1),2(1X,F5.1),
+     +           2(1X,F7.1),2(1X,F7.1))')
+     +           idate,csubset,
+     +           (r8arr(i,z), i = 1,4),(r8arr2(i,z), i = 1,6),
+     +           (r8arr3(i,z), i = 1,3), (r8arr4(i,z), i = 1,3),
+     +           (r8arr5(i,z), i = 1,3),(r8arr6(i,z), i = 1,2)
+          DO y = 1,200
+            IF ( outstg (y:y) .eq. '*') THEN
+              outstg (y:y) = 'm'
+            ENDIF
+          ENDDO
 
-
-              CALL UFBINT  ( 11, r8arr, MXMN, MXLV, nlv, ostr(1))
-              CALL UFBINT  ( 11, r8arr2, MXMN, MXLV, nlv, ostr(2))
-              CALL UFBINT  ( 11, r8arr3, MXMN, MXLV, nlv, ostr(3))
-              CALL UFBINT  ( 11, r8arr4, MXMN, MXLV, nlv1, ostr(4))
-              CALL UFBINT  ( 11, r8arr5, MXMN, MXLV, nlv, ostr(5))
-              CALL UFBINT  ( 11, r8arr6, MXMN, MXLV, nlv, ostr(6))
-
-           minu=int(r8arr2(2,1))
-            write (unit=minute, FMT='(I2)') minu
-            DO k=1,2
-               IF ( minute (k:k) .eq. ' ') THEN
-                 minute (k:k) = '0'
-               ENDIF
-            ENDDO
-           DO z = 1,nlv1
-              WRITE (UNIT=outstg, FMT='(I10,1x,A8,1X,A6,
-     +          1X,F6.1,4(1X,F4.1), 
-     +          2(1X,F6.1),2(1X,F7.1),2(1X,F6.1),1X,F7.1,
-     +          2(1X,F5.1),2(1X,F5.1),
-     +          2(1X,F7.1),2(1X,F7.1))')
-     +          idate,csubset,
-     +          (r8arr(i,z), i = 1,4),(r8arr2(i,z), i = 1,6),
-     +          (r8arr3(i,z), i = 1,3), (r8arr4(i,z), i = 1,3),
-     +          (r8arr5(i,z), i = 1,3),(r8arr6(i,z), i = 1,2)
-             DO y = 1,200
-              IF ( outstg (y:y) .eq. '*') THEN
-                 outstg (y:y) = 'm'
-              ENDIF
-             ENDDO
-
-             read(outstg,21) M10,M1,M2,M3,M4,M5,M6,M7
-             read(minute,22) M11
-21           format(A10,44X,A6,1X,A6,1X,A7,1X,A7,23X,A5,1X,A5,1X,A5)         
-22           format(A2)          
+          read(outstg,21) M10,M1,M2,M3,M4,M5,M6,M7
+          read(minute,22) M11
+21        format(A10,44X,A6,1X,A6,1X,A7,1X,A7,23X,A5,1X,A5,1X,A5)         
+22        format(A2)          
  
-             iflag =iflag+1
-             j=iflag
-
-             CALL READMval(M1,lat(j))
-             CALL READMval(M2,lon(j))
-             CALL READMval(M3,zx1(j))
-             CALL READMval(M4,zx2(j))
-             CALL READMval(M5,tt(j))
-             CALL READMval(M6,d(j))
-             CALL READMval(M7,v(j))
+          CALL READMval(M1,lat)
+          CALL READMval(M2,lon)
+          CALL READMval(M3,zx1)
+          CALL READMval(M4,zx2)
+          CALL READMval(M5,tt)
+          CALL READMval(M6,d)
+          CALL READMval(M7,v)
  
-             date(j)=M10
-             mins(j)=M11
-             zx(j)=99999.9
-             if(zx1(j) .ne. 0 .and. zx1(j) < 99999 ) then
-               zx(j)= zx1(j)
-             end if
-             if(zx(j) > 99999 .and. zx2(j) .ne. 0
-     &       .and. zx2(j) < 99999 ) then 
-                zx(j)= zx2(j)
-             end if
+          date=M10
+          mins=M11
+          zx=99999.9
+          if(zx1.ne.0 .and. zx1<99999) then
+            zx=zx1
+          end if
+          if(zx>99999 .and. zx2.ne. 0 .and. zx2<99999) then 
+            zx=zx2
+          end if
 
-           ENDDO 
+c         Write output
+          if (iflag.eq.0) then
+            write(iou,fmt='(a10)') date_tag
+            iflag=1
+          endif
 
-
-
-              CALL READSB  ( 11, ierrsb )
-
-              IF  ( ierrsb .ne. 0 )  THEN
-
-                  msgok = .false.
-
-              ELSE
-              END IF
-
-            END DO
-
-        END DO
-
-1000    if (iflag .ne. 0) then
-
-         write(iou,fmt='(a10)') date_tag
-         do k = 1,iflag
-           if(slat <= lat(k) .and. nlat >= lat(k) .and.
-     &       wlon <= lon(k) .and. elon >= lon(k)) then
-             write(iou,111)isurf,dname,dname,date(k),mins(k),
-     &       lat(k),lon(k),ter,dslp,nlev,ibogus
-             write(iou,112)pr(k),zx(k),tt(k),td(k),d(k),v(k)
+          if(slat<=lat .and. nlat>=lat .and.
+     &       wlon<=lon .and. elon>=lon) then
+             write(iou,111) isurf,dname,dname,date,mins,
+     &       lat,lon,ter,dslp,nlev,ibogus
+             write(iou,112) pr,zx,tt,td,d,v
            endif
-          enddo
 111       format(i1,2(1x,a6),1x,a10,a2,4(f7.1,1x),i3,1x,i1)
 112       format(6(f7.1,1x))
 
-        endif
-          write(*,*)'nlev ', nlev
-2000    stop 99999
+        ENDDO
+      END DO
 
-        END
+C*-----------------------------------------------------------------------
+2000  stop 99999
 
+      END
+
+C*-----------------------------------------------------------------------
       SUBROUTINE READMval(M1,fl)
-           character*8 M1
-           dumm=99999.9
-           if(M1(1:1) ==  'm') then
-               fl = dumm
-           else
-               read(M1,*)fl
-           endif
+      character*8 M1
+      dumm=99999.9
+      if(M1(1:1) == 'm') then
+        fl = dumm
+      else
+        read(M1,*)fl
+      endif
 
-       RETURN
-         END
+      RETURN
+      END

--- a/src/bufr_craft2ob.f
+++ b/src/bufr_craft2ob.f
@@ -115,7 +115,7 @@ c            write(*,*)' idate: ',idate,'  ',csubset
         IF (ierr .eq.  -1) THEN
           WRITE(*,*) '[bufr_craft2ob]....all records read, Exit'
           CALL CLOSBF(11)
-          GOTO 1000 
+          GOTO 2000 
         END IF
 
 C*      At this point, we have a data subset within the

--- a/src/bufr_sat2ob.f
+++ b/src/bufr_sat2ob.f
@@ -150,7 +150,7 @@ C*            reading actual data values:
                ENDIF
               ENDDO
 
-              read(outstg,21,end=1000) M10,M1,M2,M3,M4,M5,M6
+              read(outstg,21,end=2000) M10,M1,M2,M3,M4,M5,M6
               read(minute,22) M11
 
 21            format(A10,76X,A6,1X,A7,1X,A6,1X,A7,1X,A5,2X,A5)            

--- a/src/bufr_sat2ob.f
+++ b/src/bufr_sat2ob.f
@@ -24,7 +24,7 @@
 
         CHARACTER     csubset*8, inf*200, outstg*200
         CHARACTER*80  ostr(NSTR)
-        INTEGER       y, z, idate
+        INTEGER       y, z, idate, iflag
 
         ostr(1)='SAID GCLONG SCLF RPID'
         ostr(2)='SIDP SWCM YEAR MNTH DAYS'
@@ -78,7 +78,8 @@ C*      Open output file
         open(iou,file=fout,status='unknown',form='formatted')
         write(iou,fmt='(a10)') date_tag
 
-        nlev = 1
+        iflag=0
+        nlev=1
         dumm=99999.9
 
         isurf = 0
@@ -155,7 +156,10 @@ C*            reading actual data values:
 
 21            format(A10,76X,A6,1X,A7,1X,A6,1X,A7,1X,A5,2X,A5)            
 22            format(A2)
- 
+
+C*-----------------------------------------------------------------------
+c         Prepare output
+
               CALL READMval(M1,lat)
               CALL READMval(M2,lon)
               CALL READMval(M3,tt)
@@ -170,6 +174,10 @@ C*            reading actual data values:
               end if
 
 c        write to output file
+              if (iflag.eq.0) then
+                write(iou,fmt='(a10)') date_tag
+                iflag=1
+              endif
               if(slat<=lat .and. nlat>=lat .and. wlon<=lon .and. 
      &        elon>=lon) then
                  write(iou,111)isurf,dname,dname,date,mins,

--- a/src/bufr_sat2ob.f
+++ b/src/bufr_sat2ob.f
@@ -3,39 +3,28 @@
         PARAMETER       ( NVAR = 17 )
         PARAMETER       ( NSTR = 4 )
 
-        COMMON /BITBUF/ MAXBYT,IBIT,IBAY(5000),MBYT(32),MBAY(5000,32)
-
         REAL*8          r8arr ( MXMN, MXLV ), r8arr2(MXMN, MXLV ),
      +                  r8arr3 ( MXMN, MXLV ), r8arr4(MXMN, MXLV ) 
 
-        PARAMETER       ( MXBF = 16000 )
+        parameter (iu=9, iou=10)
 
-        parameter(iu=9,iou=10,nz=9999999)
-
-        dimension pr(nz),tt(nz),td(nz)
-        integer  xht,nlev,i, iargc, n,minu,k
-        real  xpr,xu,xv
-        real  temp,v(nz),zx(nz),d(nz)
-        real  lat(nz), lon(nz)
-        real xt,xtd
-        character*30 fin,fout
-        character*10  date_tag,date(nz)
+        real pr,tt,td
+        integer xht, nlev, i, iargc, n, minu, k
+        real xpr, xu, xv
+        real temp, v, zx, d
+        real lat, lon
+        real xt, xtd
+        character*30 fin, fout
+        character*10  date_tag, date
         character*6 dname
-        character   argv*300,minute*2,M11*2,mins(nz)*2
+        character argv*300, minute*2, M11*2, mins*2
         character*12 ilev
         character*12 M10,M1,M2,M3,M4,M5,M6
-        real wlon,elon,slat,nlat
+        real wlon, elon, slat, nlat
 
-        CHARACTER       cbfmsg*(MXBF),
-     +                  csubset*8, inf*200, outstg*200
-
-        CHARACTER*80   ostr(NSTR)
-
-        INTEGER         ibfmsg ( MXBF / 4 ), ln, code,y,z,idate
-
-        LOGICAL         msgok
-
-        EQUIVALENCE     ( cbfmsg (1:4), ibfmsg (1) )
+        CHARACTER     csubset*8, inf*200, outstg*200
+        CHARACTER*80  ostr(NSTR)
+        INTEGER       y, z, idate
 
         ostr(1)='SAID GCLONG SCLF RPID'
         ostr(2)='SIDP SWCM YEAR MNTH DAYS'
@@ -87,25 +76,23 @@ c*        read(*,fmt='(a10)') date_tag
 
 C*      Open output file
         open(iou,file=fout,status='unknown',form='formatted')
+        write(iou,fmt='(a10)') date_tag
 
-        iflag = 0
         nlev = 1
         dumm=99999.9
 
         isurf = 0
         ibogus = 0
         ter = dumm
-        dslp= dumm
-        do k=1,nz
-         date(k)='MMMMMMMMMM'
-         mins(k)='MM' 
-          pr(k)=dumm
-          zx(k)=dumm
-          tt(k)=dumm
-          td(k)=dumm
-          d(k)=dumm
-          v(k)=dumm
-        enddo
+        dslp = dumm
+        date='MMMMMMMMMM'
+        mins='MM' 
+        pr=dumm
+        zx=dumm
+        tt=dumm
+        td=dumm
+        d=dumm
+        v=dumm
 
 C*      Identify BUFR file to the BUFRLIB software.  DX BUFR tables
 C*      are embedded within the first few messages of the BUFR file
@@ -119,8 +106,6 @@ C*      (i.e. YYYYMMDDHHMM ).
 
         CALL DATELEN  ( 10 )
      
-        ln=0 
-
 C*-----------------------------------------------------------------------
         DO WHILE  ( .true. )
 
@@ -129,28 +114,19 @@ C*          Read the next BUFR message.
            call readns(11,csubset,idate,ierr)
 c            write(*,*)' idate: ',idate,'  ',csubset
             IF  ( ierr .eq.  -1 )  THEN
-                write(*,*) '....all records read, Exit'
+                write(*,*) '[bufr_sat2ob]....all records read, Exit'
                 CALL CLOSBF  ( 11 )
-                Goto 1000 
+                goto 2000 
             END IF
-
-            msgok = .true.
-
-            DO WHILE  ( msgok )
-
-C*		    Read the next data subset from the BUFR message.
-		    IF (IREADSB (11) .ne. 0) THEN
-		        msgok = .false.
-		    ELSE
 
 C*            At this point, we have a data subset within the
 C*            internal arrays of BUFRLIB, and we can now begin
 C*            reading actual data values:
 
-              CALL UFBINT  ( 11, r8arr, MXMN, MXLV, nlv, ostr(1))
-              CALL UFBINT  ( 11, r8arr2, MXMN, MXLV, nlv, ostr(2))
-              CALL UFBINT  ( 11, r8arr3, MXMN, MXLV, nlv, ostr(3))
-              CALL UFBINT  ( 11, r8arr4, MXMN, MXLV, nlv, ostr(4))
+              CALL UFBINT(11, r8arr, MXMN, MXLV, nlv, ostr(1))
+              CALL UFBINT(11, r8arr2, MXMN, MXLV, nlv, ostr(2))
+              CALL UFBINT(11, r8arr3, MXMN, MXLV, nlv, ostr(3))
+              CALL UFBINT(11, r8arr4, MXMN, MXLV, nlv, ostr(4))
 
             minu=int(r8arr3(2,1))
             write (unit=minute, FMT='(I2)') minu
@@ -161,7 +137,7 @@ C*            reading actual data values:
                ENDIF
             ENDDO
 
-            DO z = 1,nlv
+            DO z = 1, nlv
               WRITE (UNIT=outstg, FMT='(I10,1x,A8, 
      +          3(1X,F5.1),1X,A8,1X,F5.1, 
      +          1X,F4.1,1X,F6.1,4(1x,F4.1),2(1X,F7.2),1X,F6.2,
@@ -180,48 +156,35 @@ C*            reading actual data values:
 21            format(A10,76X,A6,1X,A7,1X,A6,1X,A7,1X,A5,2X,A5)            
 22            format(A2)
  
-              iflag =iflag+1
-              j=iflag
+              CALL READMval(M1,lat)
+              CALL READMval(M2,lon)
+              CALL READMval(M3,tt)
+              CALL READMval(M4,pr)
+              CALL READMval(M5,d)
+              CALL READMval(M6,v)
 
-              CALL READMval(M1,lat(j))
-              CALL READMval(M2,lon(j))
-              CALL READMval(M3,tt(j))
-              CALL READMval(M4,pr(j))
-              CALL READMval(M5,d(j))
-              CALL READMval(M6,v(j))
-
-              date(j)=M10
-              mins(j)=M11
-              if(pr(j) .ne. 0 .and. pr(j) < 99999 ) then
-                pr(j)= pr(j)/100
+              date=M10
+              mins=M11
+              if(pr.ne.0 .and. pr<99999 ) then
+                pr=pr/100
               end if
 
-            END DO           
-            END IF
+c        write to output file
+              if(slat<=lat .and. nlat>=lat .and. wlon<=lon .and. 
+     &        elon>=lon) then
+                 write(iou,111)isurf,dname,dname,date,mins,
+     &                         lat,lon,ter,dslp,nlev,ibogus
+                 write(iou,112)pr,zx,tt,td,d,v
+              endif
+111      format(i1,2(1x,a6),1x,a10,a2,4(f7.1,1x),i3,1x,i1)
+112      format(6(f7.1,1x))
+
             END DO
         END DO
 
 C*-----------------------------------------------------------------------
-C* Write to output file
-C*-----------------------------------------------------------------------
 
-1000    if (iflag .ne. 0) then
-          write(iou,fmt='(a10)') date_tag
- 
-          do k = 1,iflag
-           if(slat <= lat(k) .and. nlat >= lat(k) .and.
-     &      wlon <= lon(k) .and. elon >= lon(k)) then
-            write(iou,111)isurf,dname,dname,date(k),mins(k),
-     &        lat(k),lon(k),ter,dslp,nlev,ibogus
-            write(iou,112)pr(k),zx(k),tt(k),td(k),d(k),v(k)
-           endif
-          enddo
-111      format(i1,2(1x,a6),1x,a10,a2,4(f7.1,1x),i3,1x,i1)
-112      format(6(f7.1,1x))
-
-        endif
-
-2000    stop 99999        
+2000    stop 99999     
 
         END
 

--- a/src/bufr_upa2ob.f
+++ b/src/bufr_upa2ob.f
@@ -1,300 +1,263 @@
-        PARAMETER       ( MXMN = 8 )
-        PARAMETER       ( MXLV = 220 )
-        PARAMETER       ( NVAR = 13 )
-        PARAMETER       ( NSTR = 3 )
+      PARAMETER       ( MXMN = 8 )
+      PARAMETER       ( MXLV = 220 )
+      PARAMETER       ( NVAR = 13 )
+      PARAMETER       ( NSTR = 3 )
 
-        COMMON /BITBUF/ MAXBYT,IBIT,IBAY(5000),MBYT(32),MBAY(5000,32)
+      REAL*8 r8arr(MXMN, MXLV), r8arr2(MXMN, MXLV),
+     +       r8arr3(MXMN, MXLV)
 
-        REAL*8          r8arr ( MXMN, MXLV ), r8arr2(MXMN, MXLV ),
-     +                  r8arr3 ( MXMN, MXLV ) 
+      parameter(iu=9,iou=10,nz=9999999)
+      dimension pr(nz),tt(nz),td(nz)
+      integer  xht,nlev,i, iargc, n,minu,k
+      real  xu,xv,xy,xm,xh,xmm,xd
+      real  temp,v(nz),zx(nz),d(nz),ter(nz)
+      real  lat(nz), lon(nz)
+      real xt,xtd,xtt
+      character*80 fin,fout
+      character*10  date_tag, date(nz),M10,xpr
+      character   argv*300,minute*2,M11*2,mins(nz)*2 
+      character*6 dname,staid(nz),M20
+      character*3 ilev
+      character*8 M1,M2,min,M3,M4,M5,xlat,xlon
+      real wlon,elon,slat,nlat
 
-        PARAMETER       ( MXBF = 16000 )
+      CHARACTER csubset*8, inf*200,outstg*211
+      INTEGER y,z,idate
 
-        parameter(iu=9,iou=10,nz=9999999)
-        dimension pr(nz),tt(nz),td(nz)
-        integer  xht,nlev,i, iargc, n,minu,k
-        real  xu,xv,xy,xm,xh,xmm,xd
-        real  temp,v(nz),zx(nz),d(nz),ter(nz)
-        real  lat(nz), lon(nz)
-        real xt,xtd,xtt
-        character*80 fin,fout
-        character*10  date_tag, date(nz),M10,xpr
-        character   argv*300,minute*2,M11*2,mins(nz)*2 
-        character*6 dname,staid(nz),M20
-        character*3 ilev
-        character*8 M1,M2,min,M3,M4,M5,xlat,xlon
-        real wlon,elon,slat,nlat
+      CHARACTER*80 ostr(NSTR)
 
-        CHARACTER       cbfmsg*(MXBF),
-     +                  csubset*8, inf*200,outstg*211
-
-        CHARACTER*80   ostr(NSTR)
-
-        INTEGER         ibfmsg ( MXBF / 4 ), ln, code,y,z,idate
-
-        LOGICAL         msgok
-
-        EQUIVALENCE     ( cbfmsg (1:4), ibfmsg (1) )
-
-        ostr(1)='RPID YEAR MNTH DAYS'
-        ostr(2)='HOUR MINU CLAT CLON SELV'
-        ostr(3)='TMDB TMDP PRLC WDIR WSPD'
+      ostr(1)='RPID YEAR MNTH DAYS'
+      ostr(2)='HOUR MINU CLAT CLON SELV'
+      ostr(3)='TMDB TMDP PRLC WDIR WSPD'
     
 C*-----------------------------------------------------------------------
 c*    Read the command-line arguments
 c*      
-        n = iargc()
-        IF (n .GE. 2) THEN
-          call getarg( 1, argv )
-          inf=argv
-          call getarg(2,argv)
-          date_tag=argv
-          IF (n .eq. 6) THEN  ! User-specified lat/lon boundaries
-            call getarg(3,argv)
-            read(argv,*) wlon
-            call getarg(4,argv)
-            read(argv,*) elon
-            call getarg(5,argv)
-            read(argv,*) slat
-            call getarg(6,argv)
-            read(argv,*) nlat
-            write(*,*) 'Lon/lat boundaries: ',wlon,elon,slat,nlat
-          ELSE  ! Default lon/lat boundaries
-            slat = -90.
-            nlat = 90.
-            wlon = -180.
-            elon = 180.
-          END IF
-        ELSE
-          write(*,*) 'Usage: bufr_aircar2ob.x gdas.adpsfc.t<HH>z.
+      n = iargc()
+      IF (n .GE. 2) THEN
+        call getarg( 1, argv )
+        inf=argv
+        call getarg(2,argv)
+        date_tag=argv
+        IF (n .eq. 6) THEN  ! User-specified lat/lon boundaries
+          call getarg(3,argv)
+          read(argv,*) wlon
+          call getarg(4,argv)
+          read(argv,*) elon
+          call getarg(5,argv)
+          read(argv,*) slat
+          call getarg(6,argv)
+          read(argv,*) nlat
+          write(*,*) 'Lon/lat boundaries: ',wlon,elon,slat,nlat
+        ELSE  ! Default lon/lat boundaries
+          slat = -90.
+          nlat = 90.
+          wlon = -180.
+          elon = 180.
+        END IF
+      ELSE
+        write(*,*) 'Usage: bufr_aircar2ob.x gdas.adpsfc.t<HH>z.
      +<YYYYMMDD>.bufr.be <YYYYMMDDHH> west_lon east_lon 
      +south_lat north_lat'
-          STOP
-        END IF
+        STOP
+      END IF
 
 C*-----------------------------------------------------------------------
+C*    Open the BUFR messages file.
+      OPEN(UNIT=11, FILE=inf, form='unformatted')
 
-C*      Open the BUFR messages file.
+      dname='  TEMP'
+      fout="Upper"//date_tag//'.obs'
 
-c*        write(*,*) 'enter input BUFR file?'
-c*        read(*,'(a)') inf 
-        OPEN  ( UNIT = 11, FILE =inf,form='unformatted' )
+C*    Open output file
+      open(18, file=fout, status='unknown', form='formatted')
 
-c*        write(*,*) 'Date_tag (YYYYMMDDHH) : '
-c*        read(*,fmt='(a10)') date_tag
+      iflag = 0
+      dumm=99999.9
 
-        dname='  TEMP'
-        fout= "Upper"//date_tag//'.obs'
-
-C*      Open the BUFR tables file.
-
-C*        OPEN  ( UNIT = 12, FILE = 'bufrtab.example' )
-
-C*      Open output file
-
-        open(18,file=fout,status='unknown',form='formatted')
-
-        iflag = 0
-        dumm=99999.9
-
-        iupper = 0
-        ibogus = 0
-        dslp= dumm
-        do k=1,nz
-         date(k)='MMMMMMMMMM'
-         mins(k)='MM'
-         staid(k)='MMMMMM'
-          ter(k)=dumm
-          pr(k)=dumm
-          zx(k)=dumm
-          tt(k)=dumm
-          td(k)=dumm
-          d(k)=dumm
-          v(k)=dumm
-        enddo
+      iupper=0
+      ibogus=0
+      dslp=dumm
+      do k=1,nz
+        date(k)='MMMMMMMMMM'
+        mins(k)='MM'
+        staid(k)='MMMMMM'
+        ter(k)=dumm
+        pr(k)=dumm
+        zx(k)=dumm
+        tt(k)=dumm
+        td(k)=dumm
+        d(k)=dumm
+        v(k)=dumm
+      enddo
 
 C*      Associate the tables file with the messages file, and identify
 C*      the latter to the BUFRLIB software.
 
-        CALL OPENBF  ( 11, 'IN', 11 )
+      CALL OPENBF(11, 'IN', 11)
 
 C*      Specify that we would like IDATE values returned using 10 digits
 C*      (i.e. YYYYMMDDHH ).
 
-        CALL DATELEN  ( 10 )
+      CALL DATELEN(10)
      
-        ln=0 
+      ln=0 
 
-        DO WHILE  ( .true. )
+C*-----------------------------------------------------------------------
+      DO WHILE ( .true. )
 
-C*          Read the next BUFR message.
-
-           call readns(11,csubset,idate,ierr)
-C*           code = IUPBS1(MBAY,33) 
-C*            write(*,*)' idate: ',idate,'  ',csubset,' ',code
+C*      Read the next BUFR message.
+        CALL READNS(11,csubset,idate,ierr)
 c            write(*,*)' idate: ',idate,'  ',csubset
-            IF  ( ierr .eq.  -1 )  THEN
-                write(*,*) '....all records read, Exit'
-                CALL CLOSBF  ( 11 )
-                Goto 1000 
-            END IF
 
-            msgok = .true.
+        IF (ierr .eq.  -1) THEN
+          WRITE (*,*) '[bufr_upa2ob]....all records read, Exit'
+          CALL CLOSBF  ( 11 )
+          GOTO 1000 
+        END IF
 
+C*      At this point, we have a data subset within the
+C*      internal arrays of BUFRLIB, and we can now begin
+C*      reading actual data values:
 
-            DO WHILE  ( msgok )
-
-
-C*            At this point, we have a data subset within the
-C*            internal arrays of BUFRLIB, and we can now begin
-C*            reading actual data values:
-
-
-              CALL UFBINT  ( 11, r8arr, MXMN, MXLV, nlv, ostr(1))
-              CALL UFBINT  ( 11, r8arr2, MXMN, MXLV, nlv, ostr(2))
-              CALL UFBINT  ( 11, r8arr3, MXMN, MXLV, nlv, ostr(3))
+        CALL UFBINT(11, r8arr,  MXMN, MXLV, nlv, ostr(1))
+        CALL UFBINT(11, r8arr2, MXMN, MXLV, nlv, ostr(2))
+        CALL UFBINT(11, r8arr3, MXMN, MXLV, nlv, ostr(3))
 
         minu=int(r8arr2(2,2))
         write (unit=minute, FMT='(I2)') minu
         DO k=1,2
-c           IF ( minute (k:k) .eq. ' ') THEN
+           IF ( minute (k:k) .eq. ' ') THEN
               minute (k:k) = '0'
-c           ENDIF
+           ENDIF
         ENDDO
+
         DO z = 1,nlv
-         IF(r8arr3(3,z) .lt. 10E9) THEN  
-              WRITE (UNIT=outstg, FMT='(I10,1x A8,1X,A6, 
-     +          1X,F6.1,4(1x,F4.1),2(1X,F7.2),1X,F6.2,
-     +          1X,F6.2,1X,F6.1,1X,F8.1,1X,F5.1,1x,F6.2,1X,I4,1X,I6)') 
+          IF(r8arr3(3,z) .lt. 10E9) THEN  
+             WRITE (UNIT=outstg, FMT='(I10,1x A8,1X,A6,1X,F6.1,
+     +          4(1x,F4.1),2(1X,F7.2),1X,F6.2,1X,F6.2,1X,F6.1,1X,
+     +          F8.1,1X,F5.1,1x,F6.2,1X,I4,1X,I6)')
      +          idate,csubset,
      +          (r8arr(i,1), i = 1,4),
      +          (r8arr2(i,1), i = 1,5),(r8arr3(i,z), i = 1,5),
      +          nlv,z
-          DO y = 1, 211
-           IF ( outstg (y:y) .eq. '*' ) THEN
-              outstg (y:y) = 'm'
-           ENDIF
-          ENDDO
+             DO y = 1, 211
+                IF ( outstg (y:y) .eq. '*' ) THEN
+                  outstg (y:y) = 'm'
+                ENDIF
+             ENDDO
          
-          read(outstg,21)M10,xn1,M20,xy,
-     &       xm,xd,xh,min,
-     &       xlat,xlon,M5,M1,M2,xpr,M3,M4
-          read(minute,22) M11
-!          write(*,*)M10,xlat,xlon,M5,M1,M2,xpr,M3,M4
-21        format(A10,1X,A8,1X,A6,1X,
-     &       A6,4(1x,A4),2(1X,A7),1X,A6,1X
-     &       A6,1X,A6,1X,A8,1X,A5,1x,A6)       
-22            format(A2)
+             read(outstg,21) M10,xn1,M20,xy,xm,xd,xh,min,
+     &                       xlat,xlon,M5,M1,M2,xpr,M3,M4
+             read(minute,22) M11
+!             write(*,*)M10,xlat,xlon,M5,M1,M2,xpr,M3,M4
+21           format(A10,1X,A8,1X,A6,1X,A6,4(1x,A4),2(1X,A7),
+     &              1X,A6,1X,A6,1X,A6,1X,A8,1X,A5,1x,A6)       
+22           format(A2)
 
-          iflag =iflag+1
-          j=iflag
+             iflag=iflag+1
+             j=iflag
 
+C*-----------------------------------------------------------------------
+c            Prepare output
 
-          CALL READMval(M1,tt(j))
-          CALL READMval(M2,td(j))
-          CALL READMval(M3,d(j))
-          CALL READMval(M4,v(j))
-          CALL READMval(M5,ter(j))
-          CALL READMval(xlat,lat(j))
-          CALL READMval(xlon,lon(j))
-          CALL READMval(xpr,pr(j))
+             CALL READMval(M1,tt(j))
+             CALL READMval(M2,td(j))
+             CALL READMval(M3,d(j))
+             CALL READMval(M4,v(j))
+             CALL READMval(M5,ter(j))
+             CALL READMval(xlat,lat(j))
+             CALL READMval(xlon,lon(j))
+             CALL READMval(xpr,pr(j))
         
-          if(pr(j) .ne. 0 .and. pr(j) .ne. 99999.9 ) then
-                  pr(j)= pr(j)/100
-          end if
- 
-          date(j)=M10
-          mins(j)=M11
-          staid(j)=M20
+             if(pr(j).ne.0 .and. pr(j).ne.99999.9) then
+                pr(j)= pr(j)/100
+             end if
 
+             date(j)=M10
+             mins(j)=M11
+             staid(j)=M20
          ENDIF 
-        ENDDO
-
-              CALL READSB  ( 11, ierrsb )
-
-              IF  ( ierrsb .ne. 0 )  THEN
-
-                  msgok = .false.
-
-              ELSE
-              END IF
-
-            END DO
-
         END DO
+      END DO
 
-1000   if (iflag .ne. 0) then 
+C*-----------------------------------------------------------------------
+1000  if (iflag .ne. 0) then 
         iflag1=0
         iflag2=1
-      iflag3=1
-          write(18,fmt='(a10)') date_tag
-       alat1=9999
-       alon1=9999
-          l=1
-          do k = 1,iflag 
+        iflag3=1
+        write(18,fmt='(a10)') date_tag
+        alat1=9999
+        alon1=9999
+        l=1
+        do k = 1, iflag 
+          if(slat<=lat(k) .and. nlat>=lat(k) .and. 
+     &       wlon<=lon(k) .and. elon>=lon(k)) then
 
-        if(slat <= lat(k) .and. nlat >= lat(k) .and. 
-     &   wlon <= lon(k) .and. elon >= lon(k)) then
-
-        if(alat1 .ne. lat(k) .and. alon1 .ne. lon(k)) then
-            alat1=lat(k) 
-          alon1=lon(k)
-            if(iflag1.ne.0) then
-             CALL SORTWRITE(pr,zx,tt,td,d,v,l,l1,m)
-           write(18,111)iupper,dname,staid(l),
-     &         date(l),mins(l),
-     &         lat(l),lon(l),ter(l),dslp,m-l+1,ibogus
-              do i=l,m
-               write(18,112)pr(i),zx(i),tt(i),td(i),d(i),v(i)
-              enddo
-!              write(*,*)l,' ',m,' ',l1
-            iflag2=1
+            if(alat1.ne.lat(k) .and. alon1.ne.lon(k)) then
+               alat1=lat(k)
+               alon1=lon(k)
+               if(iflag1.ne.0) then
+                  CALL SORTWRITE(pr,zx,tt,td,d,v,l,l1,m)
+                  write(18,111) iupper,dname,staid(l),
+     &                          date(l),mins(l),
+     &                          lat(l),lon(l),ter(l),dslp,
+     &                          m-l+1,ibogus
+                  do i=l,m
+                    write(18,112)pr(i),zx(i),tt(i),td(i),d(i),v(i)
+                  enddo
+!                 write(*,*)l,' ',m,' ',l1
+                  iflag2=1
+               endif
+               iflag1=1
+               l=k
+            endif
+            l1=k
           endif
-            iflag1=1
-          l=k
-          endif
-          l1=k
-       endif
-         enddo
-111    format(i1,1x,a6,1x,a6,1x,a10,a2,4(f7.1,1x),i3,1x,i1)
-112    format(6(f7.1,1x))
+        enddo
+111     format(i1,1x,a6,1x,a6,1x,a10,a2,4(f7.1,1x),i3,1x,i1)
+112     format(6(f7.1,1x))
       
-      CALL SORTWRITE(pr,zx,tt,td,d,v,l,l1,m)
-      write(18,111)iupper,dname,staid(l),date(l),
-     &  lat(l),lon(l),ter(l),dslp,m-l+1,ibogus
-         do i=l,m
-           write(18,112)pr(i),zx(i),tt(i),td(i),d(i),v(i)
-         enddo
+        CALL SORTWRITE(pr,zx,tt,td,d,v,l,l1,m)
+        write(18,111) iupper,dname,staid(l),date(l),
+     &                lat(l),lon(l),ter(l),dslp,m-l+1,ibogus
+        do i=l,m
+          write(18,112)pr(i),zx(i),tt(i),td(i),d(i),v(i)
+        enddo
 
         close(18)
-       endif
-!        write(*,*)'nlev ', nlev
+      endif
+
+C*-----------------------------------------------------------------------
+!       write(*,*)'nlev ', nlev
 2000  stop 99999
 
-        END
+      END
 
+C*-----------------------------------------------------------------------
       SUBROUTINE READMval(M1,fl)
-           character*8 M1 
-           dumm=99999.9
-            if(M1(1:1) ==  'm') then
-               fl = dumm
-           else
-               read(M1,*)fl
-           endif
+      character*8 M1 
+      dumm=99999.9
+      if(M1(1:1) ==  'm') then
+         fl = dumm
+      else
+         read(M1,*)fl
+      endif
 
-       RETURN
-         END
+      RETURN
+      END
 
-       SUBROUTINE SORTWRITE(pr,zx,tt,td,d,v,l,k,m)
-       parameter(nz=999999)
+C*-----------------------------------------------------------------------
+      SUBROUTINE SORTWRITE(pr,zx,tt,td,d,v,l,k,m)
+      parameter(nz=9999999)
 
-        dimension pr(nz),tt(nz),td(nz)
-        real  temp,v(nz),zx(nz),d(nz)
-        dimension prt(nz),ttt(nz),tdt(nz)
-        real  vt(nz),zxt(nz),dt(nz)
+      dimension pr(nz),tt(nz),td(nz)
+      real temp,v(nz),zx(nz),d(nz)
+      dimension prt(nz),ttt(nz),tdt(nz)
+      real vt(nz),zxt(nz),dt(nz)
       
       do i=l,k-1
-         do j= i+1,k
+        do j= i+1,k
           if (pr(i).lt.pr(j)) then
              call SWAPTWO(pr(i),pr(j))
              call SWAPTWO(zx(i),zx(j))
@@ -305,43 +268,43 @@ c           ENDIF
           endif 
         enddo
       enddo
-        m=l 
-        do i=l+1,k
+      m=l 
+      do i=l+1,k
         if(pr(i).eq.pr(m))then
            pr(m)=pr(i)
-            if(zx(i)<99999) then
-               zx(m)=zx(i)
-            endif
-            if(tt(i)<99999) then
-               tt(m)=tt(i)
-            endif
-            if(td(i)<99999) then
-               td(m)=td(i)
-            endif
-            if(v(i)<99999) then
-               v(m)=v(i)
-            endif
-            if(d(i)<99999) then
-               d(m)=d(i)
-            endif
-         else
-          m=m+1
-            pr(m)=pr(i)
-            zx(m)=zx(i)
-            tt(m)=tt(i)
-            td(m)=td(i)
-            v(m)=v(i)
-            d(m)=d(i)
-          endif
-        enddo
-      
+           if(zx(i)<99999) then
+              zx(m)=zx(i)
+           endif
+           if(tt(i)<99999) then
+              tt(m)=tt(i)
+           endif
+           if(td(i)<99999) then
+              td(m)=td(i)
+           endif
+           if(v(i)<99999) then
+              v(m)=v(i)
+           endif
+           if(d(i)<99999) then
+              d(m)=d(i)
+           endif
+        else
+           m=m+1
+           pr(m)=pr(i)
+           zx(m)=zx(i)
+           tt(m)=tt(i)
+           td(m)=td(i)
+           v(m)=v(i)
+           d(m)=d(i)
+        endif
+      enddo
 
       RETURN
       END
 
+C*-----------------------------------------------------------------------
       SUBROUTINE SWAPTWO(X1,X2)
-        temp=X1
-        X1=X2
+      temp=X1
+      X1=X2
       X2=temp
-        RETURN
+      RETURN
       END


### PR DESCRIPTION
Updated BUFR decoders to fix issue with potentially missing observations while reading the BUFR files.  All decoders (except the upper air decoder) now print output immediately after reading each BUFR subset, rather than storing the obs in array caches before printing output at the end of the program.